### PR TITLE
ST-667: Add JSON schema format support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,7 @@ typings/
 # next.js build output
 .next
 
+# JetBrains IDEA
+.idea
+
 dist/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Quickstart
 
-By default, Obfuscator will replace any values defined in the schema of type `password` with `**********`.
+By default, Obfuscator will replace any values defined in the schema of type `password` or type `string` and format `password` with `**********`.
 
 ### Example
 
@@ -15,6 +15,7 @@ import { Obfuscator } from '@swimlane/obfuscator';
 
 const obj = {
   foo: 'bar',
+  xyzzy: 'secret',
   fizz: 'buzz'
 };
 const schema = {
@@ -22,6 +23,10 @@ const schema = {
   properties: {
     foo: {
       type: 'password'
+    },
+    xyzzy: {
+      type: 'string',
+      format: 'password'
     },
     fizz: {
       type: 'string'
@@ -32,6 +37,7 @@ const schema = {
 console.log(Obfuscator.value(obj, schema));
 // {
 //   "foo": "**********",
+//   "xyzzy": "**********",
 //   "fizz": "buzz"
 // }
 ```
@@ -47,7 +53,7 @@ This function will obfuscate a value based on a JSON schema provided.
 - _replace_: _(optional)_ The value to obfuscate with. By default, this is `**********`. It can be a:
   - _string_: Any value you want to replace it with. (ex. `'[ REDACTED ]'`)
   - _function_: A function that accepts `(value, key)` and returns a string. This is useful if you want to obfuscate differently based on the value of key name. (ex. `(value, key) => 'REDACTED ' + value.length`)
-- _types_: _(optional)_ An array of JSON schema types you want to redact. By default, this is `['password']`
+- _types_: _(optional)_ An array of JSON schema types you want to redact. By default, this is `[{ type: 'password' }, { type: 'string', format: 'password' }]`
 
 ### Obfuscator.unObfuscate(newValue, prevValue, [replaceString])
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,24 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -407,6 +425,19 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -434,6 +465,15 @@
         "type-detect": "^4.0.0"
       }
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -455,6 +495,40 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -533,6 +607,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -568,6 +648,12 @@
       "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
       "dev": true
     },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -590,6 +676,15 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -605,6 +700,12 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -615,6 +716,12 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
       "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "http-signature": {
@@ -653,6 +760,51 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -667,6 +819,12 @@
       "requires": {
         "punycode": "2.x.x"
       }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -735,6 +893,12 @@
       "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -751,6 +915,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsprim": {
@@ -770,6 +940,18 @@
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
       "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
       "dev": true
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      }
     },
     "lodash": {
       "version": "4.17.11",
@@ -796,6 +978,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
     },
     "mime-db": {
@@ -869,6 +1057,41 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      }
     },
     "nyc": {
       "version": "13.0.1",
@@ -2007,6 +2230,12 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2016,10 +2245,26 @@
         "wrappy": "1"
       }
     },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
@@ -2027,6 +2272,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      }
     },
     "pathval": {
       "version": "1.1.0",
@@ -2038,6 +2292,18 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pidtree": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
+      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
+      "dev": true
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "prettier": {
@@ -2063,6 +2329,17 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
     },
     "request": {
       "version": "2.88.0",
@@ -2149,6 +2426,33 @@
       "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
       "dev": true
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "dev": true,
+      "requires": {
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2172,6 +2476,38 @@
           "dev": true
         }
       }
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -2202,6 +2538,17 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
+      }
+    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -2210,6 +2557,12 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "supports-color": {
       "version": "5.4.0",
@@ -2358,6 +2711,16 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -2367,6 +2730,15 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "chai": "^4.1.2",
     "codacy-coverage": "^3.0.0",
     "mocha": "^5.2.0",
+    "npm-run-all": "^4.1.5",
     "nyc": "^13.0.1",
     "prettier": "^1.14.2",
     "rimraf": "^2.6.2",

--- a/src/Obfuscator.ts
+++ b/src/Obfuscator.ts
@@ -1,27 +1,47 @@
 export type TransformFunc = (input: any) => any;
 
-export class Obfuscator {
-  /* The default replacement value */
-  static defaultReplaceString = '**********';
-  static defaultReplaceTypes = ['password'];
+export interface ObfuscateTypeFormat {
+  /**
+   * Type to obfuscate.
+   */
+  type: string;
 
   /**
-   * Obfuscate a value
-   * Defaults to any value of type 'password'
+   * Format to obfuscate.
+   */
+  format?: string;
+}
+
+export class Obfuscator {
+
+  /* The default replacement value */
+  static defaultReplaceString = '**********';
+
+  /* The default schema types to obfuscate */
+  static defaultReplaceTypes: ObfuscateTypeFormat[] = [
+    { type: 'password' }, // backward compatibility
+    { type: 'string', format: 'password' }
+  ];
+
+  /**
+   * Obfuscate a value based on a JSON schema.
+   *
+   * @remarks
+   * Defaults to any value of type 'password' or type 'string' with format 'password'.
    *
    * @static
-   * @param {*} value The value value
-   * @param {*} schema The schema describing the value
-   * @param {string|TransformFunc} [replace=Obfuscator.defaultReplaceString] The default replace string, can be function
-   * @param {string[]} [types=Obfuscator.defaultReplaceTypes] They types to replace
-   * @returns {*}
+   * @param value The value to obfuscate.
+   * @param schema The JSON schema describing the value.
+   * @param replace The string to replace/obfuscate with, can be function.
+   * @param types The types of values to replace.
+   * @returns The obfuscated value.
    * @memberof Obfuscator
    */
   static value(
     value: any,
     schema: any,
     replace: string | TransformFunc = Obfuscator.defaultReplaceString,
-    types: string[] = Obfuscator.defaultReplaceTypes
+    types: string[] | ObfuscateTypeFormat[] = Obfuscator.defaultReplaceTypes
   ): any {
     if (typeof schema !== 'object' || schema === null || !('type' in schema)) {
       return value;
@@ -35,7 +55,7 @@ export class Obfuscator {
       return Obfuscator.array(value, schema, replace, types);
     }
 
-    if (types.indexOf(schema.type) !== -1) {
+    if (Obfuscator.predicateTypeFormat(schema, types)) {
       return replaceFunc(value);
     } else {
       return value;
@@ -43,22 +63,24 @@ export class Obfuscator {
   }
 
   /**
-   * Obfuscate an object based on a JSON schema
-   * Defaults to any value of type 'password'
+   * Obfuscate an object based on a JSON schema.
+   *
+   * @remarks
+   * Defaults to any value of type 'password' or type 'string' with format 'password'.
    *
    * @static
-   * @param {*} obj The object to obfuscate
-   * @param {*} schema The JSON schema describing the object
-   * @param {string|TransformFunc} [replace=Obfuscator.defaultReplaceString] What to replace value with, can be function
-   * @param {string[]} [types=Obfuscator.defaultReplaceTypes] What types of values to replace
-   * @returns {*}
+   * @param obj The object to obfuscate.
+   * @param schema The JSON schema describing the object.
+   * @param replace The string to replace/obfuscate with, can be function.
+   * @param types The types of values to replace.
+   * @returns The obfuscated object.
    * @memberof Obfuscator
    */
   static object(
     obj: any,
     schema: any,
     replace: string | TransformFunc = Obfuscator.defaultReplaceString,
-    types: string[] = Obfuscator.defaultReplaceTypes
+    types: string[] | ObfuscateTypeFormat[] = Obfuscator.defaultReplaceTypes
   ): any {
     // check that object is an object or array
     if (typeof obj !== 'object' || obj === null) return obj;
@@ -100,22 +122,24 @@ export class Obfuscator {
   }
 
   /**
-   * Obfuscate an array based on a JSON schema
-   * Defaults to any value of type 'password'
+   * Obfuscate an array based on a JSON schema.
+   *
+   * @remarks
+   * Defaults to any value of type 'password' or type 'string' with format 'password'.
    *
    * @static
-   * @param {any[]} obj The array to obfuscate
-   * @param {*} schema The JSON schema describing the array
-   * @param {string|TransformFunc} [replace=Obfuscator.defaultReplaceString] What to replace value with, can be function
-   * @param {string[]} [types=Obfuscator.defaultReplaceTypes] What types of values to replace
-   * @returns {*}
+   * @param arr The array to obfuscate.
+   * @param schema The JSON schema describing the array.
+   * @param replace The string to replace/obfuscate with, can be function.
+   * @param types The types of values to replace.
+   * @returns The obfuscated array.
    * @memberof Obfuscator
    */
   static array(
     arr: any[],
     schema: any,
     replace: string | TransformFunc = Obfuscator.defaultReplaceString,
-    types: string[] = Obfuscator.defaultReplaceTypes
+    types: string[] | ObfuscateTypeFormat[] = Obfuscator.defaultReplaceTypes
   ): any[] {
     // check that object is an object or array
     if (typeof arr !== 'object' || arr === null) return arr;
@@ -137,7 +161,7 @@ export class Obfuscator {
     const newArr: any[] = [];
 
     for (const item of arr) {
-      if (schema.items.type && types.indexOf(schema.items.type) !== -1) {
+      if (schema.items.type && Obfuscator.predicateTypeFormat(schema.items, types)) {
         newArr.push(replaceFunc(item));
       } else {
         newArr.push(Obfuscator.value(item, schema.items, replaceFunc, types));
@@ -148,11 +172,11 @@ export class Obfuscator {
   }
 
   /**
-   * Normalize a replace string/fucntion
+   * Normalize a replace string/function.
    *
    * @static
-   * @param {(string|TransformFunc)} replace
-   * @returns {TransformFunc}
+   * @param replace String or function to replace values.
+   * @returns Transform function to replace values.
    * @memberof Obfuscator
    */
   static wrapReplace(replace: string | TransformFunc): TransformFunc {
@@ -161,15 +185,41 @@ export class Obfuscator {
   }
 
   /**
-   * Replaces obfuscated text with the previous value.
-   * Useful when accepting a modified object that contains obfuscated values that you wish to store
-   * the unobfuscated values. (basically an unobfuscator)
+   * Check if schema is one of type and optionally format.
    *
    * @static
-   * @param {*} newValue
-   * @param {*} prevValue
-   * @param {*} [replaceString=Obfuscator.defaultReplaceString]
-   * @returns {*}
+   * @param schema The JSON schema describing a field.
+   * @param types Types and optionally format to check that schema is.
+   * @returns  If schema matches any of the types provided returns true, otherwise false.
+   * @memberof Obfuscator
+   */
+  static predicateTypeFormat(schema: any, types: string[] | ObfuscateTypeFormat[]) {
+    if (schema && schema.type) {
+      for (const i in types) {
+        const type: any = types[i];
+        if (typeof type === 'string' && schema.type === type) {
+          return true;
+        } else if (type.type === schema.type && (type.format === undefined || type.format === schema.format)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Replaces obfuscated text with the previous value.
+   *
+   * @remarks
+   * Useful when accepting a modified object that contains obfuscated values that you wish to store
+   * the unobfuscated values (basically an unobfuscator).
+   *
+   * @static
+   * @param newValue The value to search for replacement string.
+   * @param prevValue The value to replace the new value if replacement string.
+   * @param replaceString The replacement string to search for.
+   * @returns The unobfuscated value.
    * @memberof Obfuscator
    */
   static unObfuscate(newValue: any, prevValue: any, replaceString = Obfuscator.defaultReplaceString): any {

--- a/tests/Obfuscator.spec.ts
+++ b/tests/Obfuscator.spec.ts
@@ -1,11 +1,19 @@
-import { Obfuscator } from '../src/Obfuscator';
+import {ObfuscateTypeFormat, Obfuscator} from '../src/Obfuscator';
 import { expect } from 'chai';
 
 describe('Obfuscator', () => {
   describe('.value()', () => {
-    it('should obfuscate a value', done => {
+    it('should obfuscate a value with password type', done => {
       const value = '12345';
       const schema = { type: 'password' };
+
+      expect(Obfuscator.value(value, schema)).to.equal(Obfuscator.defaultReplaceString);
+      done();
+    });
+
+    it('should obfuscate a value with password format', done => {
+      const value = '12345';
+      const schema = { type: 'string', format: 'password' };
 
       expect(Obfuscator.value(value, schema)).to.equal(Obfuscator.defaultReplaceString);
       done();
@@ -33,6 +41,33 @@ describe('Obfuscator', () => {
       const value = '12345';
       const schema = { type: 'string' };
       const type = ['string'];
+
+      expect(Obfuscator.value(value, schema, undefined, type)).to.equal(Obfuscator.defaultReplaceString);
+      done();
+    });
+
+    it('should obfuscate a value with a user supplied type and no format', done => {
+      const value = '12345';
+      const schema = { type: 'string' };
+      const type: ObfuscateTypeFormat[] = [{ type: 'string' }];
+
+      expect(Obfuscator.value(value, schema, undefined, type)).to.equal(Obfuscator.defaultReplaceString);
+      done();
+    });
+
+    it('should obfuscate a value with a user supplied type and any format', done => {
+      const value = '12345';
+      const schema = { type: 'string', format: 'secret' };
+      const type: ObfuscateTypeFormat[] = [{ type: 'string' }];
+
+      expect(Obfuscator.value(value, schema, undefined, type)).to.equal(Obfuscator.defaultReplaceString);
+      done();
+    });
+
+    it('should obfuscate a value with a user supplied type and format', done => {
+      const value = '12345';
+      const schema = { type: 'string', format: 'secret' };
+      const type: ObfuscateTypeFormat[] = [{ type: 'string', format: 'secret' }];
 
       expect(Obfuscator.value(value, schema, undefined, type)).to.equal(Obfuscator.defaultReplaceString);
       done();


### PR DESCRIPTION
**Changes**
Added support to obfsucate based on type and format schema definition while keeping backward support.
Added unit tests covering new parameter type.
Normailzed docs (comments and readme).
Added required npm-run-all to dev packages.
Added  IDEA folder to .gitignore